### PR TITLE
treewide: Simplify external interrupt routing

### DIFF
--- a/hw/pkg/pms_top_pkg.sv
+++ b/hw/pkg/pms_top_pkg.sv
@@ -37,6 +37,12 @@ package pms_top_pkg;
   parameter int unsigned CLUST_NB_FPU = 8; // Number of FPUs in the cluster. Default to 8 private per-core FPUs
   parameter int unsigned CLUST_NB_EXT_DIVSQRT = 1; // Number of external DIVSQRT units in the cluster. Default to 1.
 
+  parameter int unsigned NUM_EXT_INTERRUPTS = 222; // Number of external interrupts to the pms. An interrupt is considered
+                                                   // external if the interrupt source is outside the pms, which routes the
+                                                   // generated line(s) only. It equals NUM_INTERRUPTS-32-2, where NUM_INTERRUPTS
+                                                   // defaults to 256. 32 are the default internal CLINT interrupts, while 2
+                                                   // are the manager domain's DMA interrupts.
+
   import control_pulp_pkg::*;
 
   // Export AXI parameters from control_pulp
@@ -58,5 +64,5 @@ package pms_top_pkg;
   export control_pulp_pkg::axi_data_oup_ext_t;
   export control_pulp_pkg::axi_strb_oup_ext_t;
   export control_pulp_pkg::axi_addr_ext_t;
-  
+
 endpackage // pms_top_pkg

--- a/hw/pulp/control_pulp.sv
+++ b/hw/pulp/control_pulp.sv
@@ -58,6 +58,8 @@ module control_pulp import control_pulp_pkg::*; #(
   parameter int unsigned D2D_NUM_LANES = 0,
   parameter int unsigned D2D_NUM_CREDITS = 0,
 
+  parameter int unsigned NUM_EXT_INTERRUPTS = 222,
+
   // axi req and resp types
 
   // nci_cp_top Master
@@ -114,12 +116,8 @@ module control_pulp import control_pulp_pkg::*; #(
   // wdt
   output logic [1:0]                       wdt_alert_o,
   input  logic                             wdt_alert_clear_i,
-  // interrupts
-  input logic                              scg_irq_i,
-  input logic                              scp_irq_i,
-  input logic                              scp_secure_irq_i,
-  input logic [71:0]                       mbox_irq_i,
-  input logic [71:0]                       mbox_secure_irq_i,
+  // external interrupts
+  input logic [NUM_EXT_INTERRUPTS-1:0]     irq_ext_i,
 
   // inout signals are split into input, output and enables
   // spi/i2c/uart
@@ -730,11 +728,7 @@ module control_pulp import control_pulp_pkg::*; #(
     .wdt_alert_o,
     .wdt_alert_clear_i,
 
-    .scg_irq_i,
-    .scp_irq_i,
-    .scp_secure_irq_i,
-    .mbox_irq_i,
-    .mbox_secure_irq_i,
+    .irq_ext_i,
 
     .gpio_in_i,
     .gpio_out_o,

--- a/hw/pulp/control_pulp_fpga.sv
+++ b/hw/pulp/control_pulp_fpga.sv
@@ -1984,6 +1984,11 @@ module control_pulp_fpga import pms_top_pkg::*; #(
     .to_ext_req_o         (from_pl_req),
     .to_ext_resp_i        (from_pl_resp),
 
+    .d2d_clk_i  ( '0 ),
+    .d2d_data_i ( '0 ),
+    .d2d_clk_o  ( ),
+    .d2d_data_o ( ),
+
     .apb_clk_ctrl_bus   ( s_apb_clk_ctrl_bus    ),
     .clk_mux_sel_o      ( s_clk_mux_sel         ),
     .apb_pad_cfg_bus    ( s_apb_pad_cfg_bus     ),

--- a/hw/pulp/pms_top.sv
+++ b/hw/pulp/pms_top.sv
@@ -49,6 +49,8 @@ module pms_top import pms_top_pkg::*; #(
   parameter int unsigned  N_SPI = 8,
   parameter int unsigned  N_UART = 1,
 
+  parameter int unsigned  NUM_EXT_INTERRUPTS = 222,
+
   parameter int unsigned  AXI_DATA_INP_WIDTH_EXT = 64, // External parameter from nci_cp_top
   localparam int unsigned AXI_STRB_INP_WIDTH_EXT = AXI_DATA_INP_WIDTH_EXT/8,
   parameter int unsigned  AXI_DATA_OUP_WIDTH_EXT = 64, // External parameter from nci_cp_top
@@ -198,12 +200,8 @@ module pms_top import pms_top_pkg::*; #(
   // wdt
   output logic [1:0]                        wdt_alert_o,
   input logic                               wdt_alert_clear_i,
-  // interrupts
-  input logic                               scg_irq_i,
-  input logic                               scp_irq_i,
-  input logic                               scp_secure_irq_i,
-  input logic [71:0]                        mbox_irq_i,
-  input logic [71:0]                        mbox_secure_irq_i,
+  // external interrupts
+  input logic [NUM_EXT_INTERRUPTS-1:0]      irq_ext_i,
 
   // Inout signals are split into input, output and enables
 
@@ -1176,6 +1174,8 @@ module pms_top import pms_top_pkg::*; #(
     .D2D_NUM_CHANNELS (D2D_NUM_CHANNELS),
     .D2D_NUM_LANES (D2D_NUM_LANES),
     .D2D_NUM_CREDITS (D2D_NUM_CREDITS),
+    // External interrupts
+    .NUM_EXT_INTERRUPTS(NUM_EXT_INTERRUPTS),
 
      // nci_cp_top Master
     .axi_req_inp_ext_t       (axi_req_inp_ext_t),
@@ -1226,11 +1226,7 @@ module pms_top import pms_top_pkg::*; #(
     .wdt_alert_o,
     .wdt_alert_clear_i,
 
-    .scg_irq_i,
-    .scp_irq_i,
-    .scp_secure_irq_i,
-    .mbox_irq_i,
-    .mbox_secure_irq_i,
+    .irq_ext_i,
 
     .oe_qspi_sdio_o,
     .oe_qspi_csn_o,

--- a/hw/pulp/pms_top_fpga_behav.sv
+++ b/hw/pulp/pms_top_fpga_behav.sv
@@ -249,7 +249,7 @@ module pms_top_fpga_behav (
 
   // USE_D2D default is 0. If set to 1, update the other dependent parameters
   // accordingly
-  localparam int unsigned USE_D2D = 1;
+  localparam int unsigned USE_D2D = 0;
 
   control_pulp_fpga #(
     .CORE_TYPE(0),

--- a/hw/pulp/soc_domain.sv
+++ b/hw/pulp/soc_domain.sv
@@ -63,7 +63,8 @@ module soc_domain #(
     parameter int unsigned SIM_STDOUT = 0,
     parameter int unsigned MACRO_ROM = 0,
     parameter int unsigned USE_CLUSTER = 0,
-    parameter int unsigned SDMA_RT_MIDEND = 0
+    parameter int unsigned SDMA_RT_MIDEND = 0,
+    parameter int unsigned NUM_EXT_INTERRUPTS = 222
 )(
 
     input logic                               soc_clk_i,
@@ -93,11 +94,7 @@ module soc_domain #(
     output logic [1:0]                        wdt_alert_o,
     input  logic                              wdt_alert_clear_i,
 
-    input logic                               scg_irq_i,
-    input logic                               scp_irq_i,
-    input logic                               scp_secure_irq_i,
-    input logic [71:0]                        mbox_irq_i,
-    input logic [71:0]                        mbox_secure_irq_i,
+    input logic  [NUM_EXT_INTERRUPTS-1:0]     irq_ext_i,
 
     output logic [NB_CL_CORES-1:0]            dbg_irq_valid_o,
 
@@ -404,11 +401,7 @@ module soc_domain #(
         .jtag_trst_ni      (jtag_trst_ni),
         .jtag_tms_i        (jtag_tms_i),
         .jtag_tdi_i        (jtag_tdi_i),
-        .scg_irq_i         (scg_irq_i),
-        .scp_irq_i         (scp_irq_i),
-        .scp_secure_irq_i  (scp_secure_irq_i),
-        .mbox_irq_i        (mbox_irq_i),
-        .mbox_secure_irq_i (mbox_secure_irq_i),
+        .irq_ext_i,
         .wdt_alert_clear_i (wdt_alert_clear_i),
         .apb_serial_link_bus (apb_serial_link_bus),
         .apb_clk_ctrl_bus  (apb_clk_ctrl_bus),

--- a/tb/fixture_pms_top.sv
+++ b/tb/fixture_pms_top.sv
@@ -1867,7 +1867,21 @@ module fixture_pms_top;
     .clk_i    (s_soc_clk),
     .rst_ni   (s_rst_n),
     .axi_req_i(to_sim_mem_req),
-    .axi_rsp_o(to_sim_mem_resp)
+    .axi_rsp_o(to_sim_mem_resp),
+    .mon_w_valid_o ( ),
+    .mon_w_addr_o  ( ),
+    .mon_w_data_o  ( ),
+    .mon_w_id_o    ( ),
+    .mon_w_user_o  ( ),
+    .mon_w_beat_count_o ( ),
+    .mon_w_last_o  ( ),
+    .mon_r_valid_o ( ),
+    .mon_r_addr_o  ( ),
+    .mon_r_data_o  ( ),
+    .mon_r_id_o    ( ),
+    .mon_r_user_o  ( ),
+    .mon_r_beat_count_o ( ),
+    .mon_r_last_o  ( )
   );
 
   // AXI mux to allow multiple external AXI drivers towards AXI simulation memory

--- a/tb/fixture_pms_top.sv
+++ b/tb/fixture_pms_top.sv
@@ -734,9 +734,7 @@ module fixture_pms_top;
   assign                   sclIm            = w_i2c_slv_scl[0];
 
   // Control external interrupts
-  logic scg_irq, scp_irq, scp_secure_irq;
-  logic [71:0] mbox_irq, mbox_secure_irq;
-
+  logic [pms_top_pkg::NUM_EXT_INTERRUPTS-1:0] s_irq_ext;
 
   //
   // Simulation pad-frame
@@ -1212,6 +1210,7 @@ module fixture_pms_top;
     .N_I2C_SLV(pms_top_pkg::N_I2C_SLV),
     .N_SPI(pms_top_pkg::N_SPI),
     .N_UART(pms_top_pkg::N_UART),
+    .NUM_EXT_INTERRUPTS(pms_top_pkg::NUM_EXT_INTERRUPTS),
 
     // D2D link
     .USE_D2D (USE_D2D),
@@ -1358,11 +1357,7 @@ module fixture_pms_top;
     .wdt_alert_o      (),
     .wdt_alert_clear_i(1'b0),
 
-    .scg_irq_i        (scg_irq),
-    .scp_irq_i        (scp_irq),
-    .scp_secure_irq_i (scp_secure_irq),
-    .mbox_irq_i       (mbox_irq),
-    .mbox_secure_irq_i(mbox_secure_irq),
+    .irq_ext_i(s_irq_ext),
 
 
     // Inout signals are split into input, output and enables
@@ -1904,71 +1899,20 @@ module fixture_pms_top;
     .mst_resp_i (to_sim_mem_resp)
   );
 
-  // Very basic doorbell modules, one for each interrupt line (external + clint)
-  logic db_trigger_scg = 1'b0;
-  logic db_trigger_scp = 1'b0;
-  logic db_trigger_scp_secure = 1'b0;
-  logic db_scg_irq;
-  logic db_scp_irq;
-  logic db_scp_secure_irq;
-  logic [71:0] db_trigger_mbox = '0;
-  logic [71:0] db_trigger_mbox_secure = '0;
-  logic [71:0] db_mbox_irq;
-  logic [71:0] db_mbox_secure_irq;
-  // logic [31:0] db_trigger_clint;
-  // logic [31:0] db_clint_irq;
-
-  // Wrap trigger signals in one array
-  logic [255:0] db_trigger = {
-    {77{1'b0}},  // 77 (systemverilog has default:0 but that doesn't work reliably)
-    db_trigger_mbox_secure,  // 72
-    db_trigger_mbox,  // 72
-    db_trigger_scp_secure,  // 1
-    db_trigger_scp,  // 1
-    db_trigger_scg  // 1
-  };
+  // Very basic doorbell modules, one for each interrupt line. This is for fast
+  // tracking if we can trigger hardware interrupt lines.
+  logic [pms_top_pkg::NUM_EXT_INTERRUPTS-1:0] db_trigger;
+  logic [pms_top_pkg::NUM_EXT_INTERRUPTS-1:0] db;
 
   // Assign firing interrupt from doorbells to pms_top
-  assign scg_irq         = db_scg_irq;
-  assign scp_irq         = db_scp_irq;
-  assign scp_secure_irq  = db_scp_secure_irq;
-  assign mbox_irq        = db_mbox_irq;
-  assign mbox_secure_irq = db_mbox_secure_irq;
+  assign s_irq_ext = db;
 
-  doorbell i_doorbell_scg (
-    .clk_i       (s_clk_ref),
-    .rst_ni      (s_rst_n),
-    .db_trigger_i(db_trigger[0]),
-    .irq_o       (db_scg_irq)
-  );
-
-  doorbell i_doorbell_scp (
-    .clk_i       (s_clk_ref),
-    .rst_ni      (s_rst_n),
-    .db_trigger_i(db_trigger[1]),
-    .irq_o       (db_scp_irq)
-  );
-
-  doorbell i_doorbell_scp_sec (
-    .clk_i       (s_clk_ref),
-    .rst_ni      (s_rst_n),
-    .db_trigger_i(db_trigger[2]),
-    .irq_o       (db_scp_secure_irq)
-  );
-
-  for (genvar i = 0; i < 72; i++) begin : doorbell_mbox_irq
-    doorbell i_doorbell_mbox (
+  for (genvar i = 0; i < pms_top_pkg::NUM_EXT_INTERRUPTS-1; i++) begin : doorbell_irq
+    doorbell i_doorbell (
       .clk_i       (s_clk_ref),
       .rst_ni      (s_rst_n),
-      .db_trigger_i(db_trigger[i+3]),
-      .irq_o       (db_mbox_irq[i])
-    );
-
-    doorbell i_doorbell_mbox_sec (
-      .clk_i       (s_clk_ref),
-      .rst_ni      (s_rst_n),
-      .db_trigger_i(db_trigger[i+75]),
-      .irq_o       (db_mbox_secure_irq[i])
+      .db_trigger_i(db_trigger[i]),
+      .irq_o       (db[i])
     );
   end
 
@@ -2720,7 +2664,7 @@ module fixture_pms_top;
   // Interrupts control: driver tasks
   //
 
-  task db_trigger_irq(input logic [255:0] mask);
+  task db_trigger_irq(input logic [pms_top_pkg::NUM_EXT_INTERRUPTS-1:0] mask);
     db_trigger &= '0;  // make sure the irq array is zero
     db_trigger |= mask;
   endtask  // ext_irq_trigger

--- a/tb/fpga/fixture_pms_top_fpga.sv
+++ b/tb/fpga/fixture_pms_top_fpga.sv
@@ -624,7 +624,21 @@ module fixture_pms_top_fpga;
     .clk_i    (s_soc_clk),
     .rst_ni   (s_rst_n),
     .axi_req_i(to_ps_req),
-    .axi_rsp_o(to_ps_resp)
+    .axi_rsp_o(to_ps_resp),
+    .mon_w_valid_o ( ),
+    .mon_w_addr_o  ( ),
+    .mon_w_data_o  ( ),
+    .mon_w_id_o    ( ),
+    .mon_w_user_o  ( ),
+    .mon_w_beat_count_o ( ),
+    .mon_w_last_o  ( ),
+    .mon_r_valid_o ( ),
+    .mon_r_addr_o  ( ),
+    .mon_r_data_o  ( ),
+    .mon_r_id_o    ( ),
+    .mon_r_user_o  ( ),
+    .mon_r_beat_count_o ( ),
+    .mon_r_last_o  ( )
   );
 
 

--- a/tb/tb_pms_minimal.sv
+++ b/tb/tb_pms_minimal.sv
@@ -474,11 +474,7 @@ module tb_pms_minimal;
     .wdt_alert_o      (),
     .wdt_alert_clear_i('0),
 
-    .scg_irq_i        ('0),
-    .scp_irq_i        ('0),
-    .scp_secure_irq_i ('0),
-    .mbox_irq_i       ('0),
-    .mbox_secure_irq_i('0),
+    .irq_ext_i('0),
 
 
     // Inout signals are split into input, output and enables

--- a/tb/tb_scmi_doorbell_b2b.sv
+++ b/tb/tb_scmi_doorbell_b2b.sv
@@ -28,8 +28,9 @@ module tb_scmi_doorbell_b2b;
   fixture_pms_top fixt_pms ();
 
   logic [31:0] entry_point;
-  int exit_status, msg_cnt;
-  logic [255:0] irq_mask = {256{1'b0}};
+  int   exit_status;
+  int   msg_cnt = 0;
+  logic [pms_top_pkg::NUM_EXT_INTERRUPTS-1:0] irq_mask = {(pms_top_pkg::NUM_EXT_INTERRUPTS){1'b0}};
 
   // pms boot driver process (AXI)
   initial begin : axi_boot_process

--- a/tb/tb_scmi_doorbell_conc.sv
+++ b/tb/tb_scmi_doorbell_conc.sv
@@ -30,7 +30,7 @@ module tb_scmi_doorbell_conc;
 
   logic [31:0] entry_point;
   int exit_status;
-  logic [255:0] irq_mask = {256{1'b0}};
+  logic [pms_top_pkg::NUM_EXT_INTERRUPTS-1:0] irq_mask = {(pms_top_pkg::NUM_EXT_INTERRUPTS){1'b0}};
 
   // pms boot driver process (AXI)
   initial begin : axi_boot_process
@@ -95,7 +95,7 @@ module tb_scmi_doorbell_conc;
       // Program has notified the tb, trigger interrupt lines
       if (notifier[0] == 1) begin
         $display("[TB] %t - Trigger interrupts", $realtime);
-        irq_mask = {256{1'b1}};
+        irq_mask = {(pms_top_pkg::NUM_EXT_INTERRUPTS){1'b1}};
         fixt_pms.db_trigger_irq(irq_mask);
 
         #5ns fixt_pms.db_trigger_irq('0);


### PR DESCRIPTION
Use single array to make the wiring independent from EPI-specific naming conventions and integration-derived terminology