### PR TITLE
treewide: Use file lists in synthesis job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,12 +147,8 @@ gen: update-serial-link
 	sed -i 's/current_fileset/get_filesets control_pulp_exilzcu102_pms_top_fpga_0_0/g' fpga/gen/vivado_includes.tcl
 # Synthesis
 	if [[ -d nonfree ]]; then \
-	echo 'set ROOT [file normalize [file dirname [info script]]/../..]' > nonfree/gen/synopsys.tcl; \
-	echo 'lappend search_path "$$ROOT/hw/includes"' >> nonfree/gen/synopsys.tcl; \
-	echo 'lappend search_path "$$ROOT/hw/ips/axi/include"' >> nonfree/gen/synopsys.tcl; \
-	echo 'lappend search_path "$$ROOT/hw/ips/common_cells/include"' >> nonfree/gen/synopsys.tcl; \
-	echo 'lappend search_path "$$ROOT/hw/ips/register_interface/include"' >> nonfree/gen/synopsys.tcl; \
-	$(BENDER) script synopsys $(BENDER_SYNTH_TARGETS) $(BENDER_BASE_TARGETS) | grep -v 'set ROOT' >> nonfree/gen/synopsys.tcl; \
+	$(BENDER) script flist-plus $(BENDER_SYNTH_TARGETS) $(BENDER_BASE_TARGETS) > nonfree/gen/synopsys.f; \
+	sed -i 's?$(ROOT_DIR)?\$$CPROOT?g' nonfree/gen/synopsys.f; \
 	fi
 
 .PHONY: update-serial-link

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ $(export_if_def VERILATOR)
 $(export_if_def QUESTA)
 
 NONFREE_REMOTE = git@iis-git.ee.ethz.ch:pms/control-pulp-nonfree.git
-NONFREE_COMMIT = 748e821
+NONFREE_COMMIT = ee818ec
 
 .PHONY: nonfree-init
 nonfree-init:


### PR DESCRIPTION
* Use file lists instead of tcl script, still generated by Bender
* The generated file list (synopsys.f) is prefixed with the root of the repo instead of hardcoded paths, useful for third parties deliverables